### PR TITLE
Story 4.1: contrato da fonte unica de verdade

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/support/meeting_status.php';
+require_once __DIR__ . '/support/meeting_contract.php';
+
+$contract = validate_meeting_contract(require __DIR__ . '/data/meeting.php');
+
+if (!is_array($contract)) {
+    throw new RuntimeException('O contrato da reunião deve retornar um array.');
+}
+
+$timezone = (string) $contract['timezone'];
+$meeting = $contract['meeting'];
+$supportLinks = $contract['support_links'];
+
+$status = resolve_meeting_status($meeting, $timezone);
+
+return [
+    'site' => [
+        'name' => 'Grupo QuarenteNA de Narcóticos Anônimos',
+        'locale' => 'pt-BR',
+        'timezone' => $timezone,
+    ],
+    'meeting' => $meeting,
+    'meeting_status' => $status,
+    'support_links' => $supportLinks,
+];

--- a/app/data/meeting.php
+++ b/app/data/meeting.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+// Seed inicial baseado em fontes publicas do proprio ecossistema de NA.
+return [
+    'timezone' => 'America/Sao_Paulo',
+    'meeting' => [
+        'title' => 'Reunião Online do Grupo QuarenteNA',
+        'join_url' => 'https://zoom.us/j/603887055?pwd=Vy9iZXRMMFRGSVVOK2NmUERvVWRDdz09',
+        'meeting_id' => '603 887 055',
+        'password' => '992229',
+        'type' => 'fechada',
+        'starts_at' => '2026-03-24T19:30:00-03:00',
+        'ends_at' => '2026-03-24T20:00:00-03:00',
+        'status' => 'próxima reunião',
+        'status_override' => 'próxima reunião',
+        'updated_at' => '2026-03-24 05:05 BRT',
+    ],
+    'support_links' => [
+        'whatsapp' => null,
+        'report' => null,
+        'directory' => 'https://www.na.org.br/virtual/',
+    ],
+];

--- a/app/support/meeting_contract.php
+++ b/app/support/meeting_contract.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/meeting_status.php';
+
+function validate_meeting_contract(array $contract): array
+{
+    assert_required_keys($contract, ['timezone', 'meeting', 'support_links'], 'contrato');
+
+    $timezone = normalize_contract_timezone($contract['timezone']);
+    $meeting = $contract['meeting'];
+    $supportLinks = $contract['support_links'];
+
+    if (!is_array($meeting) || !is_array($supportLinks)) {
+        throw new RuntimeException('Os blocos meeting e support_links devem ser arrays.');
+    }
+
+    assert_required_keys(
+        $meeting,
+        ['title', 'join_url', 'meeting_id', 'password', 'type', 'starts_at', 'ends_at', 'status', 'status_override', 'updated_at'],
+        'meeting'
+    );
+    assert_required_keys($supportLinks, ['whatsapp', 'report', 'directory'], 'support_links');
+
+    foreach (['title', 'join_url', 'meeting_id', 'password', 'updated_at'] as $requiredStringKey) {
+        assert_non_empty_string($meeting[$requiredStringKey], 'meeting.' . $requiredStringKey);
+    }
+
+    if (!in_array($meeting['type'], ['aberta', 'fechada'], true)) {
+        throw new RuntimeException('meeting.type deve ser "aberta" ou "fechada".');
+    }
+
+    foreach (['whatsapp', 'report', 'directory'] as $supportKey) {
+        assert_nullable_string($supportLinks[$supportKey], 'support_links.' . $supportKey);
+    }
+
+    $statusField = normalize_status_label($meeting['status']);
+    $statusOverride = normalize_status_label($meeting['status_override']);
+    $manualStatus = $statusOverride ?? $statusField;
+    $startsAt = parse_meeting_datetime($meeting['starts_at'], $timezone);
+    $endsAt = parse_meeting_datetime($meeting['ends_at'], $timezone);
+    $hasStartsAt = is_string($meeting['starts_at']) && trim($meeting['starts_at']) !== '';
+    $hasEndsAt = is_string($meeting['ends_at']) && trim($meeting['ends_at']) !== '';
+
+    if (($hasStartsAt xor $hasEndsAt) && $manualStatus === null) {
+        throw new RuntimeException('Agenda parcial exige status_override manual valido.');
+    }
+
+    if (($hasStartsAt || $hasEndsAt) && $manualStatus === null && (!($startsAt instanceof DateTimeImmutable) || !($endsAt instanceof DateTimeImmutable))) {
+        throw new RuntimeException('Agenda invalida exige status_override manual valido.');
+    }
+
+    if ($startsAt instanceof DateTimeImmutable && $endsAt instanceof DateTimeImmutable && $endsAt < $startsAt) {
+        throw new RuntimeException('meeting.ends_at deve ser posterior a meeting.starts_at.');
+    }
+
+    if ($statusField !== null && $statusOverride !== null && $statusField !== $statusOverride) {
+        throw new RuntimeException('meeting.status e meeting.status_override devem permanecer sincronizados quando ambos forem definidos.');
+    }
+
+    return [
+        'timezone' => $timezone->getName(),
+        'meeting' => array_merge($meeting, [
+            'status' => $manualStatus,
+            'status_override' => $manualStatus,
+        ]),
+        'support_links' => $supportLinks,
+    ];
+}
+
+function normalize_contract_timezone(mixed $value): DateTimeZone
+{
+    if (!is_string($value) || trim($value) === '') {
+        throw new RuntimeException('timezone deve ser uma string nao vazia.');
+    }
+
+    try {
+        return new DateTimeZone($value);
+    } catch (Throwable $exception) {
+        throw new RuntimeException('timezone invalido no contrato: ' . $value, 0, $exception);
+    }
+}
+
+function assert_required_keys(array $source, array $requiredKeys, string $context): void
+{
+    foreach ($requiredKeys as $requiredKey) {
+        if (!array_key_exists($requiredKey, $source)) {
+            throw new RuntimeException('Campo obrigatorio ausente em ' . $context . ': ' . $requiredKey);
+        }
+    }
+}
+
+function assert_non_empty_string(mixed $value, string $field): void
+{
+    if (!is_string($value) || trim($value) === '') {
+        throw new RuntimeException($field . ' deve ser uma string nao vazia.');
+    }
+}
+
+function assert_nullable_string(mixed $value, string $field): void
+{
+    if ($value === null) {
+        return;
+    }
+
+    assert_non_empty_string($value, $field);
+}

--- a/app/support/meeting_status.php
+++ b/app/support/meeting_status.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+function resolve_meeting_status(array $meeting, string $timezone, ?DateTimeImmutable $now = null): array
+{
+    $manualOverride = normalize_status_label($meeting['status_override'] ?? $meeting['status'] ?? null);
+    if ($manualOverride !== null) {
+        return status_payload($manualOverride, 'manual');
+    }
+
+    $tz = normalize_contract_timezone($timezone);
+    $currentTime = $now instanceof DateTimeImmutable ? $now->setTimezone($tz) : new DateTimeImmutable('now', $tz);
+    $startsAt = parse_meeting_datetime($meeting['starts_at'] ?? null, $tz);
+    $endsAt = parse_meeting_datetime($meeting['ends_at'] ?? null, $tz);
+
+    if (!($startsAt instanceof DateTimeImmutable) || !($endsAt instanceof DateTimeImmutable)) {
+        throw new RuntimeException('Agenda invalida exige status_override manual valido.');
+    }
+
+    if ($currentTime >= $startsAt && $currentTime <= $endsAt) {
+        return status_payload('agora', 'automatic');
+    }
+
+    if ($currentTime < $startsAt && $currentTime->format('Y-m-d') === $startsAt->format('Y-m-d')) {
+        return status_payload('mais tarde hoje', 'automatic');
+    }
+
+    return status_payload('próxima reunião', 'automatic');
+}
+
+function parse_meeting_datetime(mixed $value, DateTimeZone $timezone): ?DateTimeImmutable
+{
+    if (!is_string($value) || trim($value) === '') {
+        return null;
+    }
+
+    try {
+        return (new DateTimeImmutable($value, $timezone))->setTimezone($timezone);
+    } catch (Throwable) {
+        return null;
+    }
+}
+
+function status_payload(string $label, string $source): array
+{
+    $normalized = trim($label);
+
+    return [
+        'label' => $label,
+        'source' => $source,
+        'slug' => preg_match('/^agora$/iu', $normalized) === 1
+            ? 'agora'
+            : (preg_match('/^mais tarde hoje$/iu', $normalized) === 1 ? 'mais-tarde-hoje' : 'proxima-reuniao'),
+    ];
+}
+
+function normalize_status_label(mixed $value): ?string
+{
+    if (!is_string($value) || trim($value) === '') {
+        return null;
+    }
+
+    $normalized = trim($value);
+
+    if (preg_match('/^agora$/iu', $normalized) === 1) {
+        return 'agora';
+    }
+
+    if (preg_match('/^mais tarde hoje$/iu', $normalized) === 1) {
+        return 'mais tarde hoje';
+    }
+
+    if (preg_match('/^pr[oó]xima reuni[aã]o$/iu', $normalized) === 1) {
+        return 'próxima reunião';
+    }
+
+    return null;
+}

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+$escape = static fn (mixed $value): string => htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
+$meeting = $viewData['meeting'];
+$status = $viewData['meeting_status'];
+$supportLinks = $viewData['support_links'];
+?>
+<!DOCTYPE html>
+<html lang="<?= $escape($viewData['site']['locale']) ?>">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= $escape($viewData['site']['name']) ?></title>
+</head>
+<body>
+    <main>
+        <h1><?= $escape($meeting['title'] ?? 'Reunião do Grupo QuarenteNA') ?></h1>
+        <p>Fundação técnica do MVP público em preparação.</p>
+
+        <p>
+            <a href="<?= $escape($meeting['join_url'] ?? '#') ?>">Entrar na reunião</a>
+        </p>
+
+        <dl>
+            <dt>Horário</dt>
+            <dd><?= $escape((string) ($meeting['starts_at'] ?? '')) ?></dd>
+
+            <dt>ID</dt>
+            <dd><?= $escape($meeting['meeting_id'] ?? '') ?></dd>
+
+            <dt>Senha</dt>
+            <dd><?= $escape($meeting['password'] ?? '') ?></dd>
+
+            <dt>Tipo</dt>
+            <dd><?= $escape($meeting['type'] ?? '') ?></dd>
+
+            <dt>Status</dt>
+            <dd><?= $escape($status['label']) ?></dd>
+
+            <dt>Atualizado em</dt>
+            <dd><?= $escape($meeting['updated_at'] ?? '') ?></dd>
+        </dl>
+
+        <?php if (!empty($supportLinks['directory'])): ?>
+            <p>
+                <a href="<?= $escape($supportLinks['directory']) ?>">Diretório oficial de reuniões virtuais</a>
+            </p>
+        <?php endif; ?>
+    </main>
+</body>
+</html>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+$viewData = require dirname(__DIR__) . '/app/bootstrap.php';
+
+require dirname(__DIR__) . '/app/views/home.php';

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/app/support/meeting_status.php';
+require_once dirname(__DIR__) . '/app/support/meeting_contract.php';
+
+$failures = 0;
+$assertions = 0;
+
+$assertTrue = static function (bool $condition, string $message) use (&$failures, &$assertions): void {
+    $assertions++;
+
+    if ($condition) {
+        return;
+    }
+
+    $failures++;
+    fwrite(STDERR, "FAIL: {$message}\n");
+};
+
+$assertSame = static function (mixed $expected, mixed $actual, string $message) use (&$assertTrue): void {
+    $assertTrue($expected === $actual, $message . ' (expected ' . var_export($expected, true) . ', got ' . var_export($actual, true) . ')');
+};
+
+$contract = require dirname(__DIR__) . '/app/data/meeting.php';
+$assertTrue(is_array($contract), 'O contrato deve retornar um array.');
+$assertSame(
+    ['timezone', 'meeting', 'support_links'],
+    array_keys($contract),
+    'O contrato deve expor apenas as chaves principais esperadas.'
+);
+
+$assertTrue(isset($contract['meeting']['join_url']), 'O contrato deve incluir o link principal da reunião.');
+$assertTrue(isset($contract['meeting']['title']), 'O contrato deve incluir o titulo da reuniao.');
+$assertTrue(isset($contract['meeting']['meeting_id']), 'O contrato deve incluir o ID da reunião.');
+$assertTrue(isset($contract['meeting']['password']), 'O contrato deve incluir a senha da reunião.');
+$assertTrue(isset($contract['meeting']['type']), 'O contrato deve incluir o tipo da reunião.');
+$assertTrue(isset($contract['meeting']['starts_at']), 'O contrato deve incluir starts_at.');
+$assertTrue(isset($contract['meeting']['ends_at']), 'O contrato deve incluir ends_at.');
+$assertTrue(isset($contract['meeting']['status']), 'O contrato deve incluir status.');
+$assertTrue(array_key_exists('status_override', $contract['meeting']), 'O contrato deve incluir status_override.');
+$assertTrue(isset($contract['meeting']['updated_at']), 'O contrato deve incluir updated_at.');
+$assertTrue(array_key_exists('directory', $contract['support_links']), 'O contrato deve incluir o link de diretório.');
+
+$validatedContract = validate_meeting_contract($contract);
+$assertSame('America/Sao_Paulo', $validatedContract['timezone'], 'O contrato valido deve preservar o timezone oficial.');
+$assertSame('próxima reunião', $validatedContract['meeting']['status'], 'O contrato validado deve preservar o status manual seedado.');
+
+$manualStatus = resolve_meeting_status(
+    ['status_override' => 'agora'],
+    'America/Sao_Paulo',
+    new DateTimeImmutable('2026-03-24T09:00:00-03:00')
+);
+$assertSame('agora', $manualStatus['label'], 'O status manual deve ter precedência.');
+
+$invalidManualStatus = resolve_meeting_status(
+    [
+        'status_override' => 'amanhã',
+        'starts_at' => '2026-03-24T19:30:00-03:00',
+        'ends_at' => '2026-03-24T20:00:00-03:00',
+    ],
+    'America/Sao_Paulo',
+    new DateTimeImmutable('2026-03-24T10:00:00-03:00')
+);
+$assertSame('mais tarde hoje', $invalidManualStatus['label'], 'Status manual inválido deve cair no cálculo automático.');
+
+$automaticStatus = resolve_meeting_status(
+    [
+        'starts_at' => '2026-03-24T22:30:00+00:00',
+        'ends_at' => '2026-03-24T23:00:00+00:00',
+        'status_override' => null,
+    ],
+    'America/Sao_Paulo',
+    new DateTimeImmutable('2026-03-24T10:00:00-03:00')
+);
+$assertSame('mais tarde hoje', $automaticStatus['label'], 'O cálculo automático deve normalizar offsets para o timezone oficial.');
+
+try {
+    validate_meeting_contract([
+        'timezone' => 'America/Sao_Paoloo',
+        'meeting' => $contract['meeting'],
+        'support_links' => $contract['support_links'],
+    ]);
+    $assertTrue(false, 'Timezone invalido deve disparar excecao.');
+} catch (RuntimeException) {
+    $assertTrue(true, 'Timezone invalido deve disparar excecao.');
+}
+
+try {
+    validate_meeting_contract([
+        'timezone' => 'America/Sao_Paulo',
+        'meeting' => array_merge($contract['meeting'], [
+            'starts_at' => '2026-03-24T19:30:00-03:00',
+            'ends_at' => null,
+            'status' => null,
+            'status_override' => null,
+        ]),
+        'support_links' => $contract['support_links'],
+    ]);
+    $assertTrue(false, 'Agenda parcial sem override deve disparar excecao.');
+} catch (RuntimeException) {
+    $assertTrue(true, 'Agenda parcial sem override deve disparar excecao.');
+}
+
+$viewData = require dirname(__DIR__) . '/app/bootstrap.php';
+$assertTrue(isset($viewData['meeting_status']['label']), 'O bootstrap deve preparar o status da reunião.');
+$assertSame('America/Sao_Paulo', $viewData['site']['timezone'], 'O bootstrap deve propagar o timezone do contrato.');
+$assertSame('próxima reunião', $viewData['meeting_status']['label'], 'O bootstrap deve respeitar o status manual seedado.');
+
+ob_start();
+require dirname(__DIR__) . '/public/index.php';
+$renderedHtml = (string) ob_get_clean();
+$assertTrue(str_contains($renderedHtml, '<h1>Reunião Online do Grupo QuarenteNA</h1>'), 'O smoke test deve renderizar a home pelo entrypoint público.');
+
+if ($failures > 0) {
+    exit(1);
+}
+
+fwrite(STDOUT, "PASS: " . (string) $assertions . " verificacoes\n");


### PR DESCRIPTION
## Resumo

- cria a fundacao SSR minima do MVP publico em PHP
- estabelece `app/data/meeting.php` como fonte unica de verdade
- adiciona validacao do contrato, helper de status e smoke tests em PHP

## Referencias

- Branch: `codex/feature/4-1-contrato-fonte-unica`
- Issue: #1
- Story BMAD: `_bmad-output/implementation-artifacts/4-1-contrato-da-fonte-unica-de-verdade.md`

## Testes

- `docker run --rm -v /tmp/quarentena-site-main:/app -w /app php:8.2-cli sh -lc "php -l app/data/meeting.php && php -l app/support/meeting_status.php && php -l app/support/meeting_contract.php && php -l app/bootstrap.php && php -l app/views/home.php && php -l public/index.php && php -l tests/run.php && php tests/run.php && php public/index.php >/tmp/home.html && test -s /tmp/home.html"`
