### PR TITLE
Story 1.1: home oficial com CTA primario

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -6,9 +6,14 @@ require_once __DIR__ . '/support/meeting_status.php';
 require_once __DIR__ . '/support/meeting_contract.php';
 
 $contract = validate_meeting_contract(require __DIR__ . '/data/meeting.php');
+$homeContent = require __DIR__ . '/content/home.php';
 
 if (!is_array($contract)) {
     throw new RuntimeException('O contrato da reunião deve retornar um array.');
+}
+
+if (!is_array($homeContent)) {
+    throw new RuntimeException('O conteudo da home deve retornar um array.');
 }
 
 $timezone = (string) $contract['timezone'];
@@ -26,4 +31,5 @@ return [
     'meeting' => $meeting,
     'meeting_status' => $status,
     'support_links' => $supportLinks,
+    'home_content' => $homeContent,
 ];

--- a/app/content/home.php
+++ b/app/content/home.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'hero' => [
+        'eyebrow' => 'Ponto oficial da reunião online',
+        'lead' => 'O caminho principal do grupo começa aqui: uma home leve, direta e pronta para ser usada sem JavaScript obrigatório.',
+        'cta_label' => 'Entrar na reunião',
+        'trust_note' => 'Um único CTA dominante. Nenhum atalho paralelo. Nenhuma dependência de mensagem antiga.',
+        'surface_label' => 'Canal oficial do grupo',
+        'surface_copy' => 'A reunião principal fica concentrada neste endereço. Os dados críticos continuam vindo de uma única fonte versionada.',
+    ],
+];

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -3,9 +3,6 @@
 declare(strict_types=1);
 
 $escape = static fn (mixed $value): string => htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
-$meeting = $viewData['meeting'];
-$status = $viewData['meeting_status'];
-$supportLinks = $viewData['support_links'];
 ?>
 <!DOCTYPE html>
 <html lang="<?= $escape($viewData['site']['locale']) ?>">
@@ -13,41 +10,12 @@ $supportLinks = $viewData['support_links'];
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= $escape($viewData['site']['name']) ?></title>
+    <link rel="stylesheet" href="assets/css/home.css">
 </head>
-<body>
-    <main>
-        <h1><?= $escape($meeting['title'] ?? 'Reunião do Grupo QuarenteNA') ?></h1>
-        <p>Fundação técnica do MVP público em preparação.</p>
-
-        <p>
-            <a href="<?= $escape($meeting['join_url'] ?? '#') ?>">Entrar na reunião</a>
-        </p>
-
-        <dl>
-            <dt>Horário</dt>
-            <dd><?= $escape((string) ($meeting['starts_at'] ?? '')) ?></dd>
-
-            <dt>ID</dt>
-            <dd><?= $escape($meeting['meeting_id'] ?? '') ?></dd>
-
-            <dt>Senha</dt>
-            <dd><?= $escape($meeting['password'] ?? '') ?></dd>
-
-            <dt>Tipo</dt>
-            <dd><?= $escape($meeting['type'] ?? '') ?></dd>
-
-            <dt>Status</dt>
-            <dd><?= $escape($status['label']) ?></dd>
-
-            <dt>Atualizado em</dt>
-            <dd><?= $escape($meeting['updated_at'] ?? '') ?></dd>
-        </dl>
-
-        <?php if (!empty($supportLinks['directory'])): ?>
-            <p>
-                <a href="<?= $escape($supportLinks['directory']) ?>">Diretório oficial de reuniões virtuais</a>
-            </p>
-        <?php endif; ?>
+<body class="home-body">
+    <a class="skip-link" href="#main-content">Pular para o conteudo principal</a>
+    <main id="main-content" class="page-shell">
+        <?php require __DIR__ . '/partials/hero_meeting_cta.php'; ?>
     </main>
 </body>
 </html>

--- a/app/views/partials/hero_meeting_cta.php
+++ b/app/views/partials/hero_meeting_cta.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+$heroContent = $viewData['home_content']['hero'] ?? [];
+$meeting = $viewData['meeting'];
+?>
+<section class="hero" aria-labelledby="hero-title">
+    <div class="hero__copy">
+        <p class="hero__eyebrow"><?= $escape($heroContent['eyebrow'] ?? '') ?></p>
+        <h1 id="hero-title" class="hero__title"><?= $escape($meeting['title']) ?></h1>
+        <p class="hero__lead"><?= $escape($heroContent['lead'] ?? '') ?></p>
+
+        <a
+            class="hero__cta"
+            href="<?= $escape($meeting['join_url']) ?>"
+            aria-label="<?= $escape('Entrar na reunião: ' . $meeting['title']) ?>"
+            rel="noopener noreferrer"
+        >
+            <span class="hero__cta-label"><?= $escape($heroContent['cta_label'] ?? 'Entrar na reunião') ?></span>
+            <span class="hero__cta-context"><?= $escape($meeting['title']) ?></span>
+        </a>
+
+        <p class="hero__trust"><?= $escape($heroContent['trust_note'] ?? '') ?></p>
+    </div>
+
+    <aside class="hero__surface" aria-label="Resumo oficial da home">
+        <p class="hero__surface-label"><?= $escape($heroContent['surface_label'] ?? '') ?></p>
+        <h2 class="hero__surface-title"><?= $escape($meeting['title']) ?></h2>
+        <p class="hero__surface-copy"><?= $escape($heroContent['surface_copy'] ?? '') ?></p>
+        <p class="hero__surface-meta">Atualizado em <?= $escape($meeting['updated_at']) ?></p>
+    </aside>
+</section>

--- a/public/assets/css/home.css
+++ b/public/assets/css/home.css
@@ -1,0 +1,233 @@
+:root {
+    --color-bg-deep: #081a33;
+    --color-surface: rgba(9, 29, 58, 0.78);
+    --color-surface-strong: rgba(5, 20, 41, 0.92);
+    --color-text-primary: #f7fbff;
+    --color-text-secondary: #a7c1dd;
+    --color-accent: #ffd15c;
+    --color-border: rgba(144, 183, 223, 0.22);
+    --color-shadow: rgba(1, 7, 17, 0.42);
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-6: 1.5rem;
+    --space-8: 2rem;
+    --space-12: 3rem;
+    --radius-card: 1.5rem;
+    --radius-pill: 999px;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    color-scheme: dark;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: "Atkinson Hyperlegible", "Segoe UI", sans-serif;
+    color: var(--color-text-primary);
+    background:
+        radial-gradient(circle at top left, rgba(255, 209, 92, 0.2), transparent 22rem),
+        radial-gradient(circle at 85% 20%, rgba(76, 132, 197, 0.22), transparent 18rem),
+        linear-gradient(180deg, #0d2a52 0%, var(--color-bg-deep) 42%, #061322 100%);
+}
+
+a {
+    color: inherit;
+}
+
+.skip-link {
+    position: absolute;
+    top: var(--space-4);
+    left: var(--space-4);
+    z-index: 20;
+    padding: 0.9rem 1.1rem;
+    border-radius: var(--radius-pill);
+    background: var(--color-accent);
+    color: #10233f;
+    font-weight: 700;
+    text-decoration: none;
+    transform: translateY(-200%);
+    transition: transform 160ms ease;
+}
+
+.skip-link:focus-visible {
+    transform: translateY(0);
+    outline: 3px solid #ffffff;
+    outline-offset: 2px;
+}
+
+.page-shell {
+    width: min(100% - 2rem, 72rem);
+    margin: 0 auto;
+    padding: var(--space-4) 0 var(--space-12);
+}
+
+.hero {
+    display: grid;
+    gap: var(--space-6);
+    align-items: start;
+    min-height: 100vh;
+    padding: clamp(3rem, 12vh, 6rem) 0 var(--space-8);
+}
+
+.hero__copy,
+.hero__surface {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-card);
+    background: var(--color-surface);
+    box-shadow: 0 1.5rem 4rem var(--color-shadow);
+    backdrop-filter: blur(16px);
+}
+
+.hero__copy {
+    padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.hero__eyebrow,
+.hero__surface-label {
+    margin: 0 0 var(--space-3);
+    color: var(--color-text-secondary);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+}
+
+.hero__title,
+.hero__surface-title {
+    margin: 0;
+    font-family: "Source Serif 4", "Iowan Old Style", serif;
+    letter-spacing: -0.03em;
+}
+
+.hero__title {
+    max-width: 11ch;
+    font-size: clamp(2.4rem, 11vw, 5rem);
+    line-height: 0.94;
+}
+
+.hero__lead,
+.hero__surface-copy,
+.hero__surface-meta,
+.hero__trust {
+    margin: 0;
+    max-width: 34rem;
+    line-height: 1.6;
+}
+
+.hero__lead {
+    margin-top: var(--space-6);
+    font-size: 1.05rem;
+    color: #e7f2ff;
+}
+
+.hero__cta {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 3.5rem;
+    margin-top: var(--space-8);
+    padding: 1rem 1.3rem;
+    border-radius: var(--radius-pill);
+    background: var(--color-accent);
+    color: #0f213f;
+    font-size: 1rem;
+    font-weight: 800;
+    text-decoration: none;
+    box-shadow: 0 1.25rem 2.5rem rgba(255, 209, 92, 0.28);
+    transition: transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+.hero__cta-label {
+    display: block;
+}
+
+.hero__cta-context {
+    display: block;
+    margin-top: var(--space-1);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.hero__cta:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 1.5rem 3rem rgba(255, 209, 92, 0.34);
+}
+
+.hero__cta:focus-visible {
+    outline: 3px solid #ffffff;
+    outline-offset: 4px;
+}
+
+.hero__cta:active {
+    transform: translateY(0);
+}
+
+.hero__trust {
+    margin-top: var(--space-4);
+    color: var(--color-text-secondary);
+}
+
+.hero__surface {
+    padding: clamp(1.25rem, 3vw, 2rem);
+    background: var(--color-surface-strong);
+}
+
+.hero__surface-title {
+    font-size: clamp(1.5rem, 5vw, 2.2rem);
+    line-height: 1.02;
+}
+
+.hero__surface-copy {
+    margin-top: var(--space-4);
+    color: #dcecff;
+}
+
+.hero__surface-meta {
+    margin-top: var(--space-6);
+    color: var(--color-text-secondary);
+    font-size: 0.95rem;
+}
+
+@media (min-width: 48rem) {
+    .page-shell {
+        width: min(100% - 3rem, 72rem);
+    }
+
+    .hero {
+        grid-template-columns: minmax(0, 1.2fr) minmax(18rem, 0.8fr);
+        gap: var(--space-8);
+        min-height: calc(100vh - 1rem);
+    }
+
+    .hero__cta {
+        width: auto;
+        min-width: 18rem;
+    }
+
+    .hero__surface {
+        align-self: end;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto;
+        transition-duration: 0ms !important;
+        animation-duration: 0ms !important;
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -42,6 +42,7 @@ $assertTrue(isset($contract['meeting']['status']), 'O contrato deve incluir stat
 $assertTrue(array_key_exists('status_override', $contract['meeting']), 'O contrato deve incluir status_override.');
 $assertTrue(isset($contract['meeting']['updated_at']), 'O contrato deve incluir updated_at.');
 $assertTrue(array_key_exists('directory', $contract['support_links']), 'O contrato deve incluir o link de diretório.');
+ $assertTrue(is_file(dirname(__DIR__) . '/public/assets/css/home.css'), 'A home deve expor um CSS dedicado em public/assets/css.');
 
 $validatedContract = validate_meeting_contract($contract);
 $assertSame('America/Sao_Paulo', $validatedContract['timezone'], 'O contrato valido deve preservar o timezone oficial.');
@@ -107,11 +108,25 @@ $viewData = require dirname(__DIR__) . '/app/bootstrap.php';
 $assertTrue(isset($viewData['meeting_status']['label']), 'O bootstrap deve preparar o status da reunião.');
 $assertSame('America/Sao_Paulo', $viewData['site']['timezone'], 'O bootstrap deve propagar o timezone do contrato.');
 $assertSame('próxima reunião', $viewData['meeting_status']['label'], 'O bootstrap deve respeitar o status manual seedado.');
+$assertTrue(isset($viewData['home_content']['hero']['cta_label']), 'O bootstrap deve carregar o conteudo da home.');
 
 ob_start();
 require dirname(__DIR__) . '/public/index.php';
 $renderedHtml = (string) ob_get_clean();
-$assertTrue(str_contains($renderedHtml, '<h1>Reunião Online do Grupo QuarenteNA</h1>'), 'O smoke test deve renderizar a home pelo entrypoint público.');
+$assertTrue(str_contains($renderedHtml, '<h1 id="hero-title" class="hero__title">' . $contract['meeting']['title'] . '</h1>'), 'O h1 principal da home deve consumir meeting.title da fonte unica.');
+$assertTrue(str_contains($renderedHtml, 'class="skip-link"'), 'A home deve incluir skip link visivel ao foco.');
+$assertTrue(str_contains($renderedHtml, 'href="assets/css/home.css"'), 'A home deve carregar o CSS dedicado.');
+$assertTrue(str_contains($renderedHtml, 'id="main-content"'), 'A home deve expor landmark principal com id navegavel.');
+$assertSame(1, substr_count($renderedHtml, 'class="hero__cta"'), 'A home deve renderizar exatamente um CTA primario.');
+$assertTrue(str_contains($renderedHtml, 'href="' . $contract['meeting']['join_url'] . '"'), 'O CTA deve consumir o join_url vindo da fonte unica.');
+$assertTrue(str_contains($renderedHtml, $contract['meeting']['title']), 'O CTA e a home devem expor o titulo vindo da fonte unica.');
+$assertTrue(str_contains($renderedHtml, 'rel="noopener noreferrer"'), 'O CTA externo deve proteger a navegacao.');
+$assertTrue(!str_contains($renderedHtml, '<script'), 'A home nao deve depender de JavaScript obrigatorio.');
+
+$css = (string) file_get_contents(dirname(__DIR__) . '/public/assets/css/home.css');
+$assertTrue(str_contains($css, '--color-bg-deep'), 'O CSS da home deve declarar tokens visuais do MVP.');
+$assertTrue(str_contains($css, '--color-accent'), 'O CSS da home deve declarar o acento amarelo do CTA.');
+$assertTrue(str_contains($css, '.skip-link:focus-visible'), 'O CSS da home deve estilizar o estado de foco do skip link.');
 
 if ($failures > 0) {
     exit(1);


### PR DESCRIPTION
## Resumo

- substitui a home minima por um hero SSR oficial com CTA unico e dominante
- adiciona skip link, landmark principal e CSS dedicado em `public/assets/css/home.css`
- reforca os testes para validar renderizacao sem JS e uso de `meeting.title`/`join_url` da fonte unica

## Referencias

- Branch: `codex/feature/1-1-home-oficial`
- Issue: #3
- Story BMAD: `_bmad-output/implementation-artifacts/1-1-home-oficial-com-cta-primario.md`

## Testes

- `docker run --rm -v /tmp/quarentena-site-main:/app -w /app php:8.2-cli sh -lc "php -l app/content/home.php && php -l app/views/partials/hero_meeting_cta.php && php -l tests/run.php && php tests/run.php && php public/index.php >/tmp/home.html && test -s /tmp/home.html"`
