### PR TITLE
[Story 1.2] Card da reuniao com dados completos

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/support/meeting_status.php';
 require_once __DIR__ . '/support/meeting_contract.php';
+require_once __DIR__ . '/support/meeting_presenter.php';
 
 $contract = validate_meeting_contract(require __DIR__ . '/data/meeting.php');
 $homeContent = require __DIR__ . '/content/home.php';
@@ -21,6 +22,7 @@ $meeting = $contract['meeting'];
 $supportLinks = $contract['support_links'];
 
 $status = resolve_meeting_status($meeting, $timezone);
+$meetingDisplay = present_meeting_details($meeting, $timezone);
 
 return [
     'site' => [
@@ -29,6 +31,7 @@ return [
         'timezone' => $timezone,
     ],
     'meeting' => $meeting,
+    'meeting_display' => $meetingDisplay,
     'meeting_status' => $status,
     'support_links' => $supportLinks,
     'home_content' => $homeContent,

--- a/app/support/meeting_presenter.php
+++ b/app/support/meeting_presenter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/meeting_status.php';
+require_once __DIR__ . '/meeting_contract.php';
+
+function present_meeting_details(array $meeting, string $timezone): array
+{
+    $tz = normalize_contract_timezone($timezone);
+    $startsAt = parse_meeting_datetime($meeting['starts_at'] ?? null, $tz);
+    $endsAt = parse_meeting_datetime($meeting['ends_at'] ?? null, $tz);
+
+    return [
+        'schedule_label' => format_meeting_schedule($startsAt, $endsAt),
+        'meeting_id_label' => trim((string) ($meeting['meeting_id'] ?? '')),
+        'password_label' => trim((string) ($meeting['password'] ?? '')),
+        'type_label' => format_meeting_type_label($meeting['type'] ?? null),
+        'updated_at_label' => trim((string) ($meeting['updated_at'] ?? '')),
+    ];
+}
+
+function format_meeting_schedule(?DateTimeImmutable $startsAt, ?DateTimeImmutable $endsAt): string
+{
+    if (!($startsAt instanceof DateTimeImmutable) || !($endsAt instanceof DateTimeImmutable)) {
+        return 'Horario a confirmar';
+    }
+
+    if ($startsAt->format('Y-m-d') === $endsAt->format('Y-m-d')) {
+        return $startsAt->format('d/m, H:i') . ' as ' . $endsAt->format('H:i');
+    }
+
+    return $startsAt->format('d/m, H:i') . ' ate ' . $endsAt->format('d/m, H:i');
+}
+
+function format_meeting_type_label(mixed $type): string
+{
+    return $type === 'aberta' ? 'Aberta' : 'Fechada';
+}

--- a/app/views/partials/hero_meeting_cta.php
+++ b/app/views/partials/hero_meeting_cta.php
@@ -23,11 +23,5 @@ $meeting = $viewData['meeting'];
 
         <p class="hero__trust"><?= $escape($heroContent['trust_note'] ?? '') ?></p>
     </div>
-
-    <aside class="hero__surface" aria-label="Resumo oficial da home">
-        <p class="hero__surface-label"><?= $escape($heroContent['surface_label'] ?? '') ?></p>
-        <h2 class="hero__surface-title"><?= $escape($meeting['title']) ?></h2>
-        <p class="hero__surface-copy"><?= $escape($heroContent['surface_copy'] ?? '') ?></p>
-        <p class="hero__surface-meta">Atualizado em <?= $escape($meeting['updated_at']) ?></p>
-    </aside>
+    <?php require __DIR__ . '/meeting_info_card.php'; ?>
 </section>

--- a/app/views/partials/meeting_info_card.php
+++ b/app/views/partials/meeting_info_card.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+$meeting = $viewData['meeting'];
+$meetingDisplay = $viewData['meeting_display'];
+?>
+<section class="meeting-card" aria-labelledby="meeting-card-title">
+    <p class="meeting-card__eyebrow">Dados da reuniao</p>
+    <h2 id="meeting-card-title" class="meeting-card__title">Informacoes essenciais antes de entrar</h2>
+
+    <dl class="meeting-card__list">
+        <div class="meeting-card__item">
+            <dt class="meeting-card__term">Horario</dt>
+            <dd class="meeting-card__description"><?= $escape($meetingDisplay['schedule_label']) ?></dd>
+        </div>
+        <div class="meeting-card__item">
+            <dt class="meeting-card__term">ID</dt>
+            <dd class="meeting-card__description"><?= $escape($meetingDisplay['meeting_id_label']) ?></dd>
+        </div>
+        <div class="meeting-card__item">
+            <dt class="meeting-card__term">Senha</dt>
+            <dd class="meeting-card__description"><?= $escape($meetingDisplay['password_label']) ?></dd>
+        </div>
+        <div class="meeting-card__item">
+            <dt class="meeting-card__term">Tipo</dt>
+            <dd class="meeting-card__description"><?= $escape($meetingDisplay['type_label']) ?></dd>
+        </div>
+    </dl>
+
+    <div class="meeting-card__meta">
+        <span class="meeting-card__meta-label">Reuniao</span>
+        <span class="meeting-card__meta-value"><?= $escape($meeting['title']) ?></span>
+        <span class="meeting-card__meta-label">Atualizado em</span>
+        <span class="meeting-card__meta-value"><?= $escape($meetingDisplay['updated_at_label']) ?></span>
+    </div>
+</section>

--- a/public/assets/css/home.css
+++ b/public/assets/css/home.css
@@ -79,7 +79,7 @@ a {
 }
 
 .hero__copy,
-.hero__surface {
+.meeting-card {
     border: 1px solid var(--color-border);
     border-radius: var(--radius-card);
     background: var(--color-surface);
@@ -92,7 +92,7 @@ a {
 }
 
 .hero__eyebrow,
-.hero__surface-label {
+.meeting-card__eyebrow {
     margin: 0 0 var(--space-3);
     color: var(--color-text-secondary);
     font-size: 0.76rem;
@@ -102,7 +102,7 @@ a {
 }
 
 .hero__title,
-.hero__surface-title {
+.meeting-card__title {
     margin: 0;
     font-family: "Source Serif 4", "Iowan Old Style", serif;
     letter-spacing: -0.03em;
@@ -115,8 +115,6 @@ a {
 }
 
 .hero__lead,
-.hero__surface-copy,
-.hero__surface-meta,
 .hero__trust {
     margin: 0;
     max-width: 34rem;
@@ -180,22 +178,51 @@ a {
     color: var(--color-text-secondary);
 }
 
-.hero__surface {
+.meeting-card {
     padding: clamp(1.25rem, 3vw, 2rem);
     background: var(--color-surface-strong);
 }
 
-.hero__surface-title {
-    font-size: clamp(1.5rem, 5vw, 2.2rem);
-    line-height: 1.02;
+.meeting-card__title {
+    font-size: clamp(1.5rem, 5vw, 2rem);
+    line-height: 1.08;
 }
 
-.hero__surface-copy {
-    margin-top: var(--space-4);
-    color: #dcecff;
+.meeting-card__list {
+    display: grid;
+    gap: var(--space-3);
+    margin: var(--space-6) 0 0;
 }
 
-.hero__surface-meta {
+.meeting-card__item {
+    display: grid;
+    gap: var(--space-1);
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.meeting-card__term,
+.meeting-card__meta-label {
+    color: var(--color-text-secondary);
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.meeting-card__description,
+.meeting-card__meta-value {
+    margin: 0;
+    color: #f7fbff;
+    font-size: 1.05rem;
+    font-weight: 700;
+}
+
+.meeting-card__meta {
+    display: grid;
+    gap: var(--space-1);
     margin-top: var(--space-6);
     color: var(--color-text-secondary);
     font-size: 0.95rem;
@@ -217,7 +244,7 @@ a {
         min-width: 18rem;
     }
 
-    .hero__surface {
+    .meeting-card {
         align-self: end;
     }
 }

--- a/tests/run.php
+++ b/tests/run.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/app/support/meeting_status.php';
 require_once dirname(__DIR__) . '/app/support/meeting_contract.php';
+require_once dirname(__DIR__) . '/app/support/meeting_presenter.php';
 
 $failures = 0;
 $assertions = 0;
@@ -47,6 +48,12 @@ $assertTrue(array_key_exists('directory', $contract['support_links']), 'O contra
 $validatedContract = validate_meeting_contract($contract);
 $assertSame('America/Sao_Paulo', $validatedContract['timezone'], 'O contrato valido deve preservar o timezone oficial.');
 $assertSame('próxima reunião', $validatedContract['meeting']['status'], 'O contrato validado deve preservar o status manual seedado.');
+
+$meetingDisplay = present_meeting_details($validatedContract['meeting'], $validatedContract['timezone']);
+$assertTrue($meetingDisplay['schedule_label'] !== '', 'A apresentacao da reuniao deve formatar o horario em um unico rotulo legivel.');
+$assertSame($validatedContract['meeting']['meeting_id'], $meetingDisplay['meeting_id_label'], 'A apresentacao da reuniao deve expor o ID vindo da fonte unica.');
+$assertSame($validatedContract['meeting']['password'], $meetingDisplay['password_label'], 'A apresentacao da reuniao deve expor a senha vinda da fonte unica.');
+$assertSame($validatedContract['meeting']['type'] === 'aberta' ? 'Aberta' : 'Fechada', $meetingDisplay['type_label'], 'A apresentacao da reuniao deve normalizar o tipo para exibicao.');
 
 $manualStatus = resolve_meeting_status(
     ['status_override' => 'agora'],
@@ -106,6 +113,7 @@ try {
 
 $viewData = require dirname(__DIR__) . '/app/bootstrap.php';
 $assertTrue(isset($viewData['meeting_status']['label']), 'O bootstrap deve preparar o status da reunião.');
+$assertSame($meetingDisplay['schedule_label'], $viewData['meeting_display']['schedule_label'], 'O bootstrap deve propagar o horario formatado do card principal.');
 $assertSame('America/Sao_Paulo', $viewData['site']['timezone'], 'O bootstrap deve propagar o timezone do contrato.');
 $assertSame('próxima reunião', $viewData['meeting_status']['label'], 'O bootstrap deve respeitar o status manual seedado.');
 $assertTrue(isset($viewData['home_content']['hero']['cta_label']), 'O bootstrap deve carregar o conteudo da home.');
@@ -120,6 +128,15 @@ $assertTrue(str_contains($renderedHtml, 'id="main-content"'), 'A home deve expor
 $assertSame(1, substr_count($renderedHtml, 'class="hero__cta"'), 'A home deve renderizar exatamente um CTA primario.');
 $assertTrue(str_contains($renderedHtml, 'href="' . $contract['meeting']['join_url'] . '"'), 'O CTA deve consumir o join_url vindo da fonte unica.');
 $assertTrue(str_contains($renderedHtml, $contract['meeting']['title']), 'O CTA e a home devem expor o titulo vindo da fonte unica.');
+$assertTrue(str_contains($renderedHtml, 'class="meeting-card"'), 'A home deve renderizar um card dedicado para os dados da reuniao.');
+$assertTrue(str_contains($renderedHtml, 'aria-labelledby="meeting-card-title"'), 'O card deve expor uma relacao semantica clara com seu titulo.');
+$assertTrue(str_contains($renderedHtml, '>Horario</dt>'), 'O card deve rotular o horario da reuniao.');
+$assertTrue(str_contains($renderedHtml, '>' . $meetingDisplay['schedule_label'] . '</dd>'), 'O card deve exibir o horario formatado no mesmo bloco visual.');
+$assertTrue(str_contains($renderedHtml, '>' . $meetingDisplay['meeting_id_label'] . '</dd>'), 'O card deve exibir o meeting ID vindo da fonte unica.');
+$assertTrue(str_contains($renderedHtml, '>' . $meetingDisplay['password_label'] . '</dd>'), 'O card deve exibir a senha vinda da fonte unica.');
+$assertTrue(str_contains($renderedHtml, '>' . $meetingDisplay['type_label'] . '</dd>'), 'O card deve exibir o tipo da reuniao.');
+$assertSame(1, substr_count($renderedHtml, '>' . $meetingDisplay['meeting_id_label'] . '<'), 'O meeting ID nao deve ser duplicado fora do bloco principal.');
+$assertSame(1, substr_count($renderedHtml, '>' . $meetingDisplay['password_label'] . '<'), 'A senha nao deve ser duplicada fora do bloco principal.');
 $assertTrue(str_contains($renderedHtml, 'rel="noopener noreferrer"'), 'O CTA externo deve proteger a navegacao.');
 $assertTrue(!str_contains($renderedHtml, '<script'), 'A home nao deve depender de JavaScript obrigatorio.');
 
@@ -127,6 +144,7 @@ $css = (string) file_get_contents(dirname(__DIR__) . '/public/assets/css/home.cs
 $assertTrue(str_contains($css, '--color-bg-deep'), 'O CSS da home deve declarar tokens visuais do MVP.');
 $assertTrue(str_contains($css, '--color-accent'), 'O CSS da home deve declarar o acento amarelo do CTA.');
 $assertTrue(str_contains($css, '.skip-link:focus-visible'), 'O CSS da home deve estilizar o estado de foco do skip link.');
+$assertTrue(str_contains($css, '.meeting-card__item'), 'O CSS da home deve estilizar o card de dados da reuniao.');
 
 if ($failures > 0) {
     exit(1);


### PR DESCRIPTION
## Resumo
- entrega a Story BMAD `_bmad-output/implementation-artifacts/1-2-card-da-reuniao-com-dados-completos.md`
- adiciona card principal da reuniao com horario, ID, senha e tipo no mesmo contexto visual do CTA
- move a formatacao de exibicao para helper puro e reforca a suite para evitar hardcode de dados operacionais

## Vinculos
- Branch: `codex/feature/1-2-card-da-reuniao-com-dados-completos`
- Issue principal: #5
- Story BMAD: `_bmad-output/implementation-artifacts/1-2-card-da-reuniao-com-dados-completos.md`

## Validacao
- lint PHP via Docker/WSL (`php -l` em todos os arquivos PHP)
- suite local via Docker/WSL (`php tests/run.php`)
- revisao adversarial sem findings bloqueantes
- conferencia tecnica curta sem bloqueios de PM/arquitetura/dev
