### PR TITLE
feat(home): Story 1.3 — tipo de reuniao com copy explicativa de elegibilidade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # IA
 .agents
+.claude
+.tools
 
 #BMAD
 _bmad*

--- a/app/support/meeting_presenter.php
+++ b/app/support/meeting_presenter.php
@@ -10,12 +10,14 @@ function present_meeting_details(array $meeting, string $timezone): array
     $tz = normalize_contract_timezone($timezone);
     $startsAt = parse_meeting_datetime($meeting['starts_at'] ?? null, $tz);
     $endsAt = parse_meeting_datetime($meeting['ends_at'] ?? null, $tz);
+    $type = $meeting['type'] ?? null;
 
     return [
         'schedule_label' => format_meeting_schedule($startsAt, $endsAt),
         'meeting_id_label' => trim((string) ($meeting['meeting_id'] ?? '')),
         'password_label' => trim((string) ($meeting['password'] ?? '')),
-        'type_label' => format_meeting_type_label($meeting['type'] ?? null),
+        'type_label' => format_meeting_type_label($type),
+        'type_description' => format_meeting_type_description($type),
         'updated_at_label' => trim((string) ($meeting['updated_at'] ?? '')),
     ];
 }
@@ -36,4 +38,13 @@ function format_meeting_schedule(?DateTimeImmutable $startsAt, ?DateTimeImmutabl
 function format_meeting_type_label(mixed $type): string
 {
     return $type === 'aberta' ? 'Aberta' : 'Fechada';
+}
+
+function format_meeting_type_description(mixed $type): string
+{
+    if ($type === 'aberta') {
+        return 'Aberta ao publico — qualquer pessoa pode participar.';
+    }
+
+    return 'Fechada — exclusiva para quem se identifica como dependente.';
 }

--- a/app/views/partials/meeting_info_card.php
+++ b/app/views/partials/meeting_info_card.php
@@ -24,7 +24,10 @@ $meetingDisplay = $viewData['meeting_display'];
         </div>
         <div class="meeting-card__item">
             <dt class="meeting-card__term">Tipo</dt>
-            <dd class="meeting-card__description"><?= $escape($meetingDisplay['type_label']) ?></dd>
+            <dd class="meeting-card__description">
+                <?= $escape($meetingDisplay['type_label']) ?>
+                <span class="meeting-card__type-note"><?= $escape($meetingDisplay['type_description']) ?></span>
+            </dd>
         </div>
     </dl>
 

--- a/public/assets/css/home.css
+++ b/public/assets/css/home.css
@@ -220,6 +220,14 @@ a {
     font-weight: 700;
 }
 
+.meeting-card__type-note {
+    display: block;
+    margin-top: var(--space-1);
+    color: var(--color-text-secondary);
+    font-size: 0.82rem;
+    font-weight: 400;
+}
+
 .meeting-card__meta {
     display: grid;
     gap: var(--space-1);

--- a/tests/run.php
+++ b/tests/run.php
@@ -134,11 +134,17 @@ $assertTrue(str_contains($renderedHtml, '>Horario</dt>'), 'O card deve rotular o
 $assertTrue(str_contains($renderedHtml, '>' . $meetingDisplay['schedule_label'] . '</dd>'), 'O card deve exibir o horario formatado no mesmo bloco visual.');
 $assertTrue(str_contains($renderedHtml, '>' . $meetingDisplay['meeting_id_label'] . '</dd>'), 'O card deve exibir o meeting ID vindo da fonte unica.');
 $assertTrue(str_contains($renderedHtml, '>' . $meetingDisplay['password_label'] . '</dd>'), 'O card deve exibir a senha vinda da fonte unica.');
-$assertTrue(str_contains($renderedHtml, '>' . $meetingDisplay['type_label'] . '</dd>'), 'O card deve exibir o tipo da reuniao.');
+$assertTrue(str_contains($renderedHtml, $meetingDisplay['type_label']), 'O card deve exibir o tipo da reuniao.');
 $assertSame(1, substr_count($renderedHtml, '>' . $meetingDisplay['meeting_id_label'] . '<'), 'O meeting ID nao deve ser duplicado fora do bloco principal.');
 $assertSame(1, substr_count($renderedHtml, '>' . $meetingDisplay['password_label'] . '<'), 'A senha nao deve ser duplicada fora do bloco principal.');
 $assertTrue(str_contains($renderedHtml, 'rel="noopener noreferrer"'), 'O CTA externo deve proteger a navegacao.');
 $assertTrue(!str_contains($renderedHtml, '<script'), 'A home nao deve depender de JavaScript obrigatorio.');
+
+// Story 1.3: Tipo e elegibilidade
+$assertTrue(isset($meetingDisplay['type_description']), 'O presenter deve expor type_description.');
+$assertTrue($meetingDisplay['type_description'] !== '', 'type_description nao deve ser vazio.');
+$assertTrue(str_contains($renderedHtml, 'class="meeting-card__type-note"'), 'O card deve exibir a nota explicativa do tipo.');
+$assertTrue(str_contains($renderedHtml, $meetingDisplay['type_description']), 'O card deve exibir o texto de elegibilidade do tipo.');
 
 $css = (string) file_get_contents(dirname(__DIR__) . '/public/assets/css/home.css');
 $assertTrue(str_contains($css, '--color-bg-deep'), 'O CSS da home deve declarar tokens visuais do MVP.');


### PR DESCRIPTION
## Story 1.3 — Tipo de Reuniao e Elegibilidade no Bloco Principal

Implementa a Story 1.3 do BMAD: exibe o tipo da reuniao (aberta/fechada) com copy explicativa curta no card principal.

## O que foi entregue

- `meeting_presenter.php`: novo helper `format_meeting_type_description()` retorna texto explicativo por tipo
- `meeting_info_card.php`: renderiza `.meeting-card__type-note` abaixo do rotulo de tipo
- `home.css`: estilo secundario para a nota de elegibilidade
- `tests/run.php`: 4 novos asserts cobrindo `type_description` e renderizacao HTML
- `.gitignore`: adiciona `.claude` e `.tools`

## Criterios atendidos

- Tipo aparece com copy explicativa no mesmo card (sem navegacao extra)
- Entendimento do tipo nao depende apenas de cor

## Rastreabilidade

- Issue: #7
- Story BMAD: `_bmad-output/implementation-artifacts/1-3-tipo-de-reuniao-e-elegibilidade-no-bloco-principal.md`
- Suite: PASS 56 verificacoes
