### PR TITLE
feat(home): exibe status atual da reuniao no card principal

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -21,8 +21,19 @@ $timezone = (string) $contract['timezone'];
 $meeting = $contract['meeting'];
 $supportLinks = $contract['support_links'];
 
-$status = resolve_meeting_status($meeting, $timezone);
-$meetingDisplay = present_meeting_details($meeting, $timezone);
+$referenceNow = null;
+$testNow = getenv('SITE_TEST_NOW');
+
+if (is_string($testNow) && trim($testNow) !== '') {
+    try {
+        $referenceNow = new DateTimeImmutable($testNow, new DateTimeZone($timezone));
+    } catch (Throwable) {
+        $referenceNow = null;
+    }
+}
+
+$status = resolve_meeting_status($meeting, $timezone, $referenceNow);
+$meetingDisplay = present_meeting_details($meeting, $timezone, $status);
 
 return [
     'site' => [

--- a/app/data/meeting.php
+++ b/app/data/meeting.php
@@ -13,8 +13,8 @@ return [
         'type' => 'fechada',
         'starts_at' => '2026-03-24T19:30:00-03:00',
         'ends_at' => '2026-03-24T20:00:00-03:00',
-        'status' => 'próxima reunião',
-        'status_override' => 'próxima reunião',
+        'status' => null,
+        'status_override' => null,
         'updated_at' => '2026-03-24 05:05 BRT',
     ],
     'support_links' => [

--- a/app/support/meeting_presenter.php
+++ b/app/support/meeting_presenter.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 require_once __DIR__ . '/meeting_status.php';
 require_once __DIR__ . '/meeting_contract.php';
 
-function present_meeting_details(array $meeting, string $timezone): array
+function present_meeting_details(array $meeting, string $timezone, ?array $status = null): array
 {
     $tz = normalize_contract_timezone($timezone);
     $startsAt = parse_meeting_datetime($meeting['starts_at'] ?? null, $tz);
     $endsAt = parse_meeting_datetime($meeting['ends_at'] ?? null, $tz);
     $type = $meeting['type'] ?? null;
+    $meetingStatus = present_meeting_status($status ?? resolve_meeting_status($meeting, $timezone));
 
     return [
+        'status_label' => $meetingStatus['label'],
+        'status_slug' => $meetingStatus['slug'],
+        'status_a11y_label' => $meetingStatus['a11y_label'],
         'schedule_label' => format_meeting_schedule($startsAt, $endsAt),
         'meeting_id_label' => trim((string) ($meeting['meeting_id'] ?? '')),
         'password_label' => trim((string) ($meeting['password'] ?? '')),
@@ -47,4 +51,16 @@ function format_meeting_type_description(mixed $type): string
     }
 
     return 'Fechada — exclusiva para quem se identifica como dependente.';
+}
+
+function present_meeting_status(array $status): array
+{
+    $label = trim((string) ($status['label'] ?? 'próxima reunião'));
+    $slug = trim((string) ($status['slug'] ?? 'proxima-reuniao'));
+
+    return [
+        'label' => $label,
+        'slug' => $slug,
+        'a11y_label' => 'Status da reuniao: ' . $label,
+    ];
 }

--- a/app/views/partials/meeting_info_card.php
+++ b/app/views/partials/meeting_info_card.php
@@ -10,6 +10,17 @@ $meetingDisplay = $viewData['meeting_display'];
     <h2 id="meeting-card-title" class="meeting-card__title">Informacoes essenciais antes de entrar</h2>
 
     <dl class="meeting-card__list">
+        <div class="meeting-card__item meeting-card__item--status">
+            <dt class="meeting-card__term">Status</dt>
+            <dd class="meeting-card__description">
+                <span
+                    class="meeting-status-pill meeting-status-pill--<?= $escape($meetingDisplay['status_slug']) ?>"
+                    aria-label="<?= $escape($meetingDisplay['status_a11y_label']) ?>"
+                >
+                    <?= $escape($meetingDisplay['status_label']) ?>
+                </span>
+            </dd>
+        </div>
         <div class="meeting-card__item">
             <dt class="meeting-card__term">Horario</dt>
             <dd class="meeting-card__description"><?= $escape($meetingDisplay['schedule_label']) ?></dd>

--- a/public/assets/css/home.css
+++ b/public/assets/css/home.css
@@ -203,6 +203,10 @@ a {
     background: rgba(255, 255, 255, 0.03);
 }
 
+.meeting-card__item--status {
+    gap: var(--space-2);
+}
+
 .meeting-card__term,
 .meeting-card__meta-label {
     color: var(--color-text-secondary);
@@ -226,6 +230,33 @@ a {
     color: var(--color-text-secondary);
     font-size: 0.82rem;
     font-weight: 400;
+}
+
+.meeting-status-pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem;
+    padding: 0.45rem 0.85rem;
+    border: 1px solid currentColor;
+    border-radius: var(--radius-pill);
+    font-size: 0.94rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+}
+
+.meeting-status-pill--agora {
+    color: #8ff0a9;
+    background: rgba(68, 191, 102, 0.12);
+}
+
+.meeting-status-pill--mais-tarde-hoje {
+    color: #ffe18e;
+    background: rgba(255, 209, 92, 0.16);
+}
+
+.meeting-status-pill--proxima-reuniao {
+    color: #cbe4ff;
+    background: rgba(116, 163, 228, 0.14);
 }
 
 .meeting-card__meta {

--- a/tests/run.php
+++ b/tests/run.php
@@ -39,7 +39,7 @@ $assertTrue(isset($contract['meeting']['password']), 'O contrato deve incluir a 
 $assertTrue(isset($contract['meeting']['type']), 'O contrato deve incluir o tipo da reunião.');
 $assertTrue(isset($contract['meeting']['starts_at']), 'O contrato deve incluir starts_at.');
 $assertTrue(isset($contract['meeting']['ends_at']), 'O contrato deve incluir ends_at.');
-$assertTrue(isset($contract['meeting']['status']), 'O contrato deve incluir status.');
+$assertTrue(array_key_exists('status', $contract['meeting']), 'O contrato deve incluir status.');
 $assertTrue(array_key_exists('status_override', $contract['meeting']), 'O contrato deve incluir status_override.');
 $assertTrue(isset($contract['meeting']['updated_at']), 'O contrato deve incluir updated_at.');
 $assertTrue(array_key_exists('directory', $contract['support_links']), 'O contrato deve incluir o link de diretório.');
@@ -47,9 +47,18 @@ $assertTrue(array_key_exists('directory', $contract['support_links']), 'O contra
 
 $validatedContract = validate_meeting_contract($contract);
 $assertSame('America/Sao_Paulo', $validatedContract['timezone'], 'O contrato valido deve preservar o timezone oficial.');
-$assertSame('próxima reunião', $validatedContract['meeting']['status'], 'O contrato validado deve preservar o status manual seedado.');
+$assertSame(null, $validatedContract['meeting']['status'], 'Sem override manual, o contrato validado deve permitir calculo automatico do status.');
 
-$meetingDisplay = present_meeting_details($validatedContract['meeting'], $validatedContract['timezone']);
+$meetingDisplay = present_meeting_details(
+    $validatedContract['meeting'],
+    $validatedContract['timezone'],
+    [
+        'label' => 'mais tarde hoje',
+        'slug' => 'mais-tarde-hoje',
+    ]
+);
+$assertSame('mais tarde hoje', $meetingDisplay['status_label'], 'A apresentacao da reuniao deve preservar o rotulo canonico do status para exibicao.');
+$assertSame('mais-tarde-hoje', $meetingDisplay['status_slug'], 'A apresentacao da reuniao deve propagar o slug do status.');
 $assertTrue($meetingDisplay['schedule_label'] !== '', 'A apresentacao da reuniao deve formatar o horario em um unico rotulo legivel.');
 $assertSame($validatedContract['meeting']['meeting_id'], $meetingDisplay['meeting_id_label'], 'A apresentacao da reuniao deve expor o ID vindo da fonte unica.');
 $assertSame($validatedContract['meeting']['password'], $meetingDisplay['password_label'], 'A apresentacao da reuniao deve expor a senha vinda da fonte unica.');
@@ -84,6 +93,39 @@ $automaticStatus = resolve_meeting_status(
 );
 $assertSame('mais tarde hoje', $automaticStatus['label'], 'O cálculo automático deve normalizar offsets para o timezone oficial.');
 
+$nextMeetingStatus = resolve_meeting_status(
+    [
+        'starts_at' => '2026-03-25T19:30:00-03:00',
+        'ends_at' => '2026-03-25T20:00:00-03:00',
+        'status_override' => null,
+    ],
+    'America/Sao_Paulo',
+    new DateTimeImmutable('2026-03-24T22:00:00-03:00')
+);
+$assertSame('próxima reunião', $nextMeetingStatus['label'], 'O cálculo automático deve cair para próxima reunião quando o proximo horario for em outro dia.');
+
+$liveStatus = resolve_meeting_status(
+    [
+        'starts_at' => '2026-03-24T19:30:00-03:00',
+        'ends_at' => '2026-03-24T20:00:00-03:00',
+        'status_override' => null,
+    ],
+    'America/Sao_Paulo',
+    new DateTimeImmutable('2026-03-24T19:45:00-03:00')
+);
+$assertSame('agora', $liveStatus['label'], 'O cálculo automático deve identificar quando a reuniao esta acontecendo agora.');
+
+$manualFallbackStatus = resolve_meeting_status(
+    [
+        'starts_at' => null,
+        'ends_at' => null,
+        'status_override' => 'próxima reunião',
+    ],
+    'America/Sao_Paulo',
+    new DateTimeImmutable('2026-03-24T09:00:00-03:00')
+);
+$assertSame('manual', $manualFallbackStatus['source'], 'Quando a agenda nao for suficiente, o fallback manual deve continuar valido.');
+
 try {
     validate_meeting_contract([
         'timezone' => 'America/Sao_Paoloo',
@@ -111,11 +153,12 @@ try {
     $assertTrue(true, 'Agenda parcial sem override deve disparar excecao.');
 }
 
+putenv('SITE_TEST_NOW=2026-03-24T19:45:00-03:00');
 $viewData = require dirname(__DIR__) . '/app/bootstrap.php';
 $assertTrue(isset($viewData['meeting_status']['label']), 'O bootstrap deve preparar o status da reunião.');
 $assertSame($meetingDisplay['schedule_label'], $viewData['meeting_display']['schedule_label'], 'O bootstrap deve propagar o horario formatado do card principal.');
 $assertSame('America/Sao_Paulo', $viewData['site']['timezone'], 'O bootstrap deve propagar o timezone do contrato.');
-$assertSame('próxima reunião', $viewData['meeting_status']['label'], 'O bootstrap deve respeitar o status manual seedado.');
+$assertSame('agora', $viewData['meeting_status']['label'], 'O bootstrap deve resolver o status automaticamente no timezone oficial.');
 $assertTrue(isset($viewData['home_content']['hero']['cta_label']), 'O bootstrap deve carregar o conteudo da home.');
 
 ob_start();
@@ -146,11 +189,17 @@ $assertTrue($meetingDisplay['type_description'] !== '', 'type_description nao de
 $assertTrue(str_contains($renderedHtml, 'class="meeting-card__type-note"'), 'O card deve exibir a nota explicativa do tipo.');
 $assertTrue(str_contains($renderedHtml, $meetingDisplay['type_description']), 'O card deve exibir o texto de elegibilidade do tipo.');
 
+// Story 1.4: Status da reuniao
+$assertTrue(str_contains($renderedHtml, '>Status</dt>'), 'O card deve rotular o status da reuniao.');
+$assertTrue(str_contains($renderedHtml, 'class="meeting-status-pill meeting-status-pill--agora"'), 'O card deve exibir o estado atual com pill dedicada.');
+$assertTrue(str_contains($renderedHtml, 'agora'), 'A home deve exibir exatamente um estado visivel da reuniao no bloco principal.');
+
 $css = (string) file_get_contents(dirname(__DIR__) . '/public/assets/css/home.css');
 $assertTrue(str_contains($css, '--color-bg-deep'), 'O CSS da home deve declarar tokens visuais do MVP.');
 $assertTrue(str_contains($css, '--color-accent'), 'O CSS da home deve declarar o acento amarelo do CTA.');
 $assertTrue(str_contains($css, '.skip-link:focus-visible'), 'O CSS da home deve estilizar o estado de foco do skip link.');
 $assertTrue(str_contains($css, '.meeting-card__item'), 'O CSS da home deve estilizar o card de dados da reuniao.');
+$assertTrue(str_contains($css, '.meeting-status-pill'), 'O CSS da home deve estilizar a pill de status da reuniao.');
 
 if ($failures > 0) {
     exit(1);


### PR DESCRIPTION
## Resumo
- exibe o status da reuniao no card principal
- permite calculo automatico no timezone oficial com fallback manual
- reforca os testes SSR no fluxo `wsl docker`

## Vinculos
- Branch: `codex/feature/1-4-status-reuniao`
- Issue principal: #9
- Story BMAD: `_bmad-output/implementation-artifacts/1-4-status-agora-mais-tarde-hoje-ou-proxima-reuniao.md`

## Validacao
- `wsl docker run --rm -v /mnt/c/Users/cirin/Documents/Sites/quarentena/site:/app -w /app php:8.2-cli sh -lc "php -l app/bootstrap.php && php -l app/support/meeting_presenter.php && php -l app/views/partials/meeting_info_card.php && php -l app/data/meeting.php && php -l tests/run.php"`
- `wsl docker run --rm -v /mnt/c/Users/cirin/Documents/Sites/quarentena/site:/app -w /app php:8.2-cli php tests/run.php`
