### PR TITLE
feat(home): adiciona bloco sobre o grupo quarentena

### DIFF
--- a/app/content/home.php
+++ b/app/content/home.php
@@ -22,4 +22,9 @@ return [
         'title' => 'Um espaco de apoio entre pessoas com o mesmo problema',
         'body' => 'Narcoticos Anonimos e uma irmandade onde pessoas com problemas com drogas se apoiam em recuperacao, com reunioes regulares e linguagem simples.',
     ],
+    'about_group' => [
+        'eyebrow' => 'Sobre o Grupo QuarenteNA',
+        'title' => 'Um grupo virtual com reunioes regulares',
+        'body' => 'O Grupo QuarenteNA e um grupo de Narcoticos Anonimos com reunioes online em agenda regular e um ponto oficial simples para acolher quem chega e facilitar o retorno a cada encontro.',
+    ],
 ];

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -17,6 +17,7 @@ $escape = static fn (mixed $value): string => htmlspecialchars((string) $value, 
     <main id="main-content" class="page-shell">
         <?php require __DIR__ . '/partials/hero_meeting_cta.php'; ?>
         <?php require __DIR__ . '/partials/about_na.php'; ?>
+        <?php require __DIR__ . '/partials/about_group.php'; ?>
         <?php require __DIR__ . '/partials/support_links.php'; ?>
     </main>
 </body>

--- a/app/views/partials/about_group.php
+++ b/app/views/partials/about_group.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+$aboutGroup = $viewData['home_content']['about_group'] ?? [];
+?>
+<section class="info-section info-section--group" aria-labelledby="about-group-title">
+    <div class="info-section__copy">
+        <p class="info-section__eyebrow"><?= $escape($aboutGroup['eyebrow'] ?? 'Sobre o Grupo QuarenteNA') ?></p>
+        <h2 id="about-group-title" class="info-section__title"><?= $escape($aboutGroup['title'] ?? 'Um grupo virtual com reunioes regulares') ?></h2>
+        <p class="info-section__lead"><?= $escape($aboutGroup['body'] ?? '') ?></p>
+    </div>
+</section>

--- a/public/assets/css/home.css
+++ b/public/assets/css/home.css
@@ -313,6 +313,25 @@ a {
     line-height: 1.7;
 }
 
+.info-section--group {
+    margin-top: var(--space-4);
+    background: rgba(5, 20, 41, 0.46);
+    border-style: dashed;
+}
+
+.info-section--group .info-section__eyebrow {
+    color: #ffe18e;
+}
+
+.info-section--group .info-section__title {
+    font-size: clamp(1.28rem, 3vw, 1.7rem);
+}
+
+.info-section--group .info-section__lead {
+    color: var(--color-text-secondary);
+    line-height: 1.65;
+}
+
 .support-links {
     margin-top: calc(var(--space-8) * -0.25);
     padding: var(--space-6);

--- a/tests/run.php
+++ b/tests/run.php
@@ -249,6 +249,15 @@ $assertTrue(str_contains($renderedHtml, 'class="info-section"'), 'A home deve re
 $assertTrue(str_contains($renderedHtml, $viewData['home_content']['about_na']['title']), 'O bloco O que e NA deve consumir o titulo vindo do conteudo da home.');
 $assertTrue(str_contains($renderedHtml, $viewData['home_content']['about_na']['body']), 'O bloco O que e NA deve consumir a copy curta vinda do conteudo da home.');
 
+// Story 2.3: Sobre o Grupo QuarenteNA
+$assertTrue(isset($viewData['home_content']['about_group']['body']), 'O bootstrap deve expor a copy do bloco sobre o grupo.');
+$assertTrue(str_contains(strtolower($viewData['home_content']['about_group']['body']), 'reunioes'), 'O bloco sobre o grupo deve comunicar frequencia regular.');
+$assertTrue(str_contains(strtolower($viewData['home_content']['about_group']['body']), 'narcoticos anonimos'), 'O bloco sobre o grupo deve explicar a relacao com NA.');
+$assertTrue(!str_contains($viewData['home_content']['about_group']['body'], 'Ciro'), 'O bloco sobre o grupo nao deve expor identidades pessoais.');
+$assertTrue(str_contains($renderedHtml, 'info-section info-section--group'), 'A home deve renderizar o bloco sobre o grupo abaixo do contexto inicial sobre NA.');
+$assertTrue(str_contains($renderedHtml, $viewData['home_content']['about_group']['title']), 'O bloco sobre o grupo deve consumir o titulo vindo do conteudo da home.');
+$assertTrue(str_contains($renderedHtml, $viewData['home_content']['about_group']['body']), 'O bloco sobre o grupo deve consumir a copy aprovada da home.');
+
 $viewData = array_merge($viewData, [
     'support_section' => $supportSectionWithoutLinks,
 ]);
@@ -268,6 +277,7 @@ $assertTrue(str_contains($css, '.meeting-status-pill'), 'O CSS da home deve esti
 $assertTrue(str_contains($css, '.support-links__link'), 'O CSS da home deve estilizar a secao complementar de apoio.');
 $assertTrue(str_contains($css, '.hero__welcome'), 'O CSS da home deve estilizar o bloco curto de acolhimento.');
 $assertTrue(str_contains($css, '.info-section'), 'O CSS da home deve estilizar o bloco O que e NA.');
+$assertTrue(str_contains($css, '.info-section--group'), 'O CSS da home deve estilizar o bloco sobre o grupo.');
 
 if ($failures > 0) {
     exit(1);


### PR DESCRIPTION
## Branch
- `codex/feature/2-3-sobre-grupo-quarentena`

## Issue principal
- Closes #18

## Story BMAD
- `_bmad-output/implementation-artifacts/2-3-bloco-sobre-o-grupo-quarentena.md`

## Entrega
- adiciona bloco institucional curto sobre o Grupo QuarenteNA
- comunica relacao com NA e agenda regular sem expor pessoas
- diferencia visualmente o bloco para manter a hierarquia abaixo de `O que e NA`

## Validacao
- `wsl docker run ... php -l`
- `wsl docker run ... php tests/run.php`
- revisao adversarial fresca com findings absorvidos antes do fechamento
- PARTY MODE com PM, arquitetura, dev e QA sem bloqueios para merge
