### PR TITLE
Story 2.4: explicacao aberta versus fechada

### DIFF
--- a/app/content/home.php
+++ b/app/content/home.php
@@ -27,4 +27,13 @@ return [
         'title' => 'Um grupo virtual com reunioes regulares',
         'body' => 'O Grupo QuarenteNA e um grupo de Narcoticos Anonimos com reunioes online em agenda regular e um ponto oficial simples para acolher quem chega e facilitar o retorno a cada encontro.',
     ],
+    'meeting_types' => [
+        'eyebrow' => 'Aberta ou fechada',
+        'title' => 'Como entender o tipo da reuniao',
+        'lead' => 'O tipo da reuniao ajuda a saber quem pode participar naquele encontro.',
+        'open_title' => 'Reuniao aberta',
+        'open_body' => 'Pode receber qualquer pessoa interessada em conhecer NA, inclusive familiares e profissionais.',
+        'closed_title' => 'Reuniao fechada',
+        'closed_body' => 'E voltada a membros e a quem se identifica com problema com drogas e busca recuperacao.',
+    ],
 ];

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -16,6 +16,7 @@ $escape = static fn (mixed $value): string => htmlspecialchars((string) $value, 
     <a class="skip-link" href="#main-content">Pular para o conteudo principal</a>
     <main id="main-content" class="page-shell">
         <?php require __DIR__ . '/partials/hero_meeting_cta.php'; ?>
+        <?php require __DIR__ . '/partials/meeting_types.php'; ?>
         <?php require __DIR__ . '/partials/about_na.php'; ?>
         <?php require __DIR__ . '/partials/about_group.php'; ?>
         <?php require __DIR__ . '/partials/support_links.php'; ?>

--- a/app/views/partials/meeting_types.php
+++ b/app/views/partials/meeting_types.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+$meetingTypes = $viewData['home_content']['meeting_types'] ?? [];
+?>
+<section class="info-section info-section--types" aria-labelledby="meeting-types-title">
+    <div class="info-section__copy">
+        <p class="info-section__eyebrow"><?= $escape($meetingTypes['eyebrow'] ?? 'Aberta ou fechada') ?></p>
+        <h2 id="meeting-types-title" class="info-section__title"><?= $escape($meetingTypes['title'] ?? 'Como entender o tipo da reuniao') ?></h2>
+        <p class="info-section__lead"><?= $escape($meetingTypes['lead'] ?? '') ?></p>
+    </div>
+    <div class="meeting-types-grid">
+        <article class="meeting-types-card">
+            <h3 class="meeting-types-card__title"><?= $escape($meetingTypes['open_title'] ?? 'Reuniao aberta') ?></h3>
+            <p class="meeting-types-card__body"><?= $escape($meetingTypes['open_body'] ?? '') ?></p>
+        </article>
+        <article class="meeting-types-card">
+            <h3 class="meeting-types-card__title"><?= $escape($meetingTypes['closed_title'] ?? 'Reuniao fechada') ?></h3>
+            <p class="meeting-types-card__body"><?= $escape($meetingTypes['closed_body'] ?? '') ?></p>
+        </article>
+    </div>
+</section>

--- a/public/assets/css/home.css
+++ b/public/assets/css/home.css
@@ -332,6 +332,36 @@ a {
     line-height: 1.65;
 }
 
+.info-section--types {
+    margin-top: var(--space-4);
+}
+
+.meeting-types-grid {
+    display: grid;
+    gap: var(--space-3);
+    margin-top: var(--space-6);
+}
+
+.meeting-types-card {
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.025);
+}
+
+.meeting-types-card__title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #f7fbff;
+}
+
+.meeting-types-card__body {
+    margin: var(--space-2) 0 0;
+    color: var(--color-text-secondary);
+    line-height: 1.6;
+}
+
 .support-links {
     margin-top: calc(var(--space-8) * -0.25);
     padding: var(--space-6);
@@ -436,6 +466,10 @@ a {
 
     .support-links__list {
         grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+    }
+
+    .meeting-types-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 

--- a/tests/run.php
+++ b/tests/run.php
@@ -258,6 +258,29 @@ $assertTrue(str_contains($renderedHtml, 'info-section info-section--group'), 'A 
 $assertTrue(str_contains($renderedHtml, $viewData['home_content']['about_group']['title']), 'O bloco sobre o grupo deve consumir o titulo vindo do conteudo da home.');
 $assertTrue(str_contains($renderedHtml, $viewData['home_content']['about_group']['body']), 'O bloco sobre o grupo deve consumir a copy aprovada da home.');
 
+// Story 2.4: Explicacao aberta versus fechada
+$assertTrue(isset($viewData['home_content']['meeting_types']['open_body']), 'O bootstrap deve expor a copy de reuniao aberta.');
+$assertTrue(isset($viewData['home_content']['meeting_types']['closed_body']), 'O bootstrap deve expor a copy de reuniao fechada.');
+$assertTrue(str_contains($renderedHtml, 'info-section info-section--types'), 'A home deve renderizar um bloco dedicado para explicar aberta versus fechada.');
+$assertTrue(str_contains($renderedHtml, $viewData['home_content']['meeting_types']['open_title']), 'A explicacao de reuniao aberta deve vir do conteudo da home.');
+$assertTrue(str_contains($renderedHtml, $viewData['home_content']['meeting_types']['closed_title']), 'A explicacao de reuniao fechada deve vir do conteudo da home.');
+$assertTrue(str_contains($renderedHtml, $viewData['home_content']['meeting_types']['open_body']), 'A explicacao de reuniao aberta deve expor a descricao publica aprovada.');
+$assertTrue(str_contains($renderedHtml, $viewData['home_content']['meeting_types']['closed_body']), 'A explicacao de reuniao fechada deve expor a descricao publica aprovada.');
+$assertTrue(!str_contains(strtolower($viewData['home_content']['meeting_types']['open_body']), 'nome completo'), 'A copy de reuniao aberta deve permanecer compativel com as regras publicas.');
+$assertTrue(!str_contains(strtolower($viewData['home_content']['meeting_types']['closed_body']), 'nome completo'), 'A copy de reuniao fechada deve permanecer compativel com as regras publicas.');
+
+$heroPosition = strpos($renderedHtml, 'class="hero"');
+$meetingTypesPosition = strpos($renderedHtml, 'info-section info-section--types');
+$aboutNaPosition = strpos($renderedHtml, 'info-section" aria-labelledby="about-na-title"');
+$aboutGroupPosition = strpos($renderedHtml, 'info-section info-section--group');
+$assertTrue($heroPosition !== false, 'A home deve renderizar o bloco hero.');
+$assertTrue($meetingTypesPosition !== false, 'A home deve renderizar o bloco aberta versus fechada.');
+$assertTrue($aboutNaPosition !== false, 'A home deve renderizar o bloco O que e NA.');
+$assertTrue($aboutGroupPosition !== false, 'A home deve renderizar o bloco sobre o grupo.');
+$assertTrue($heroPosition < $meetingTypesPosition, 'O bloco aberta versus fechada deve aparecer depois do hero principal.');
+$assertTrue($meetingTypesPosition < $aboutNaPosition, 'O bloco aberta versus fechada deve aparecer antes do bloco O que e NA.');
+$assertTrue($meetingTypesPosition < $aboutGroupPosition, 'O bloco aberta versus fechada deve aparecer antes do bloco sobre o grupo.');
+
 $viewData = array_merge($viewData, [
     'support_section' => $supportSectionWithoutLinks,
 ]);
@@ -278,6 +301,7 @@ $assertTrue(str_contains($css, '.support-links__link'), 'O CSS da home deve esti
 $assertTrue(str_contains($css, '.hero__welcome'), 'O CSS da home deve estilizar o bloco curto de acolhimento.');
 $assertTrue(str_contains($css, '.info-section'), 'O CSS da home deve estilizar o bloco O que e NA.');
 $assertTrue(str_contains($css, '.info-section--group'), 'O CSS da home deve estilizar o bloco sobre o grupo.');
+$assertTrue(str_contains($css, '.meeting-types-grid'), 'O CSS da home deve estilizar o bloco aberta versus fechada.');
 
 if ($failures > 0) {
     exit(1);


### PR DESCRIPTION
## Resumo

- adiciona bloco SSR com explicacao de reuniao aberta e fechada
- posiciona a secao logo abaixo do hero/card principal
- amplia testes para cobrir copy, hierarquia e estilo

## Referencias

- Branch: `codex/feature/2-4-aberta-vs-fechada`
- Issue principal: Closes #20
- Story BMAD: `_bmad-output/implementation-artifacts/2-4-explicacao-aberta-versus-fechada.md`

## Validacao

- `wsl docker ... php -l public/index.php app/bootstrap.php app/views/home.php app/views/partials/meeting_types.php app/content/home.php tests/run.php`
- `wsl docker ... php tests/run.php`
